### PR TITLE
Typo example 6.10

### DIFF
--- a/notes/Chapter-Correlated/chap6.tex
+++ b/notes/Chapter-Correlated/chap6.tex
@@ -185,7 +185,7 @@ $$ u_{1}(C, \beta[c] + (1-\beta)[b]) = 3\beta - 1, \qquad u_{1}(B, \beta[c] + (1
 The minimax strategy for Bob is to pick $\beta = 4/5$, and the minimax value for Alice is $v_1 = 7/5$.
 
 For $v_2$, we apply the same technique: if Alice plays $C$ with probability $\alpha$, we have
-$$ u_{2}(\alpha [C] + (1-\alpha)[B], c) = 2 \alpha - 1, \qquad u_{2}(\alpha [C] + (1-\alpha)[B], b) = -3\alpha + 2.  $$
+$$ u_{2}(\alpha [C] + (1-\alpha)[B], c) = 2 \alpha + 1, \qquad u_{2}(\alpha [C] + (1-\alpha)[B], b) = -3\alpha + 2.  $$
 The minimax strategy for Alice is to pick $\alpha = 1/5$, and the minimax value for Bob is $v_2 = 7/5$.
 
 In conclusion, Alice and Bob will sign any contract proposed by Charles as long as their expected payoff is at least $7/5$. In particular, Charles could tell them to both go to the cinema, or to both go to the ballet.


### PR DESCRIPTION
u_{2}(\alpha [C] + (1-\alpha)[B], c) = 2 \alpha - 1 remplacé par u_{2}(\alpha [C] + (1-\alpha)[B], c) = 2 \alpha + 1, qui donne alpha=1/5 comme dans le syllabus (avec u_{2}(\alpha [C] + (1-\alpha)[B], c) = 2 \alpha - 1, ça nous donnait alpha=3/5)